### PR TITLE
Stackheap fix

### DIFF
--- a/Preferences.lsl
+++ b/Preferences.lsl
@@ -51,11 +51,12 @@ integer g_mainPrim;
 string g_mainPrimName = ""; // By default, set to "".
 integer g_plasticPantsPrim;
 string g_plasticPantsName = "Plastic Pants";
+vector g_plasticPantsSize;
 //various diapers have different texture settings
 //ABAR Sculpted diaper bases uses repeat 1.0, 1.0 and offset .03, -.5
 string g_diaperType = "Fluffems";
 string g_resizerScriptName = ""; //change this to a resizer script name, if provided
-integer isDebug = FALSE;
+integer isDebug = TRUE;
 
 //menu variables passed to preferences
 integer g_wetLevel;
@@ -86,6 +87,7 @@ init()
     findPrims();
     if(g_plasticPantsPrim) {
         g_settingsMenu = llListReplaceList(g_settingsMenu, ["Plastic❤Pants"], 1, 1);
+        fitPlasticPants();
     }
     if(g_diaperType == "") {
         detectDiaperType();
@@ -115,6 +117,23 @@ findPrims() {
     if(g_mainPrimName == "") { // No specified prim. Look for root.
         g_mainPrim = 1;
     }
+}
+
+adjustPlasticPants() {
+    if((llGetAlpha(ALL_SIDES) != 0.0) && g_PlasticPants == TRUE) {
+        if(g_diaperType == "Fluffems") {
+            llSetLinkPrimitiveParamsFast(g_plasticPantsPrim, [PRIM_SIZE, g_plasticPantsSize]);
+        }
+    }
+    else {
+        if(g_diaperType == "Fluffems") {
+            llSetLinkPrimitiveParamsFast(g_plasticPantsPrim, [PRIM_SIZE, <.01,.01,.01>]);
+        }
+    }
+}
+
+fitPlasticPants() { //causes a .2 second llSleep, so be judicial about when it's done
+    g_plasticPantsSize = llList2Vector(llGetLinkPrimitiveParams(g_mainPrim, [PRIM_SIZE]), 0) * 1.08;
 }
 
 detectDiaperType() {
@@ -726,7 +745,8 @@ default {
             else if(msg == "Take❤Off") {
                 g_PlasticPants = FALSE;
             }
-            llMessageLinked(LINK_THIS, -3, g_currMenu + ":" + msg, NULL_KEY);
+            adjustPlasticPants();
+            sendSettings();
             offerMenu(id, g_currMenuMessage, g_currMenuButtons);
         }
         else if(msg == "Boy") {

--- a/Preferences.lsl
+++ b/Preferences.lsl
@@ -14,7 +14,6 @@ Essentially, if you edit this script you have to publicly release the result.
 (Copy/Mod/Trans on this script) This stipulation helps to grow the community and
 the software together, so everyone has access to something potentially excellent.
 
-
 *Leave this header here, but if you contribute, add your name to the list!*
 ============================================================*/
 
@@ -56,7 +55,7 @@ vector g_plasticPantsSize;
 //ABAR Sculpted diaper bases uses repeat 1.0, 1.0 and offset .03, -.5
 string g_diaperType = "Fluffems";
 string g_resizerScriptName = ""; //change this to a resizer script name, if provided
-integer isDebug = TRUE;
+integer isDebug = FALSE;
 
 //menu variables passed to preferences
 integer g_wetLevel;

--- a/menu.lsl
+++ b/menu.lsl
@@ -73,7 +73,7 @@ string g_mainPrimName = ""; // By default, set to "".
 string g_exitText = ""; //text entered here will be spoken to the owner when the diaper is removed.
 string g_diaperType = "Fluffems";
 string g_updateScript = "ME Wireless DrizzleScript Updater";
-integer isDebug = TRUE;
+integer isDebug = FALSE;
 //set isDebug to 1 (TRUE) to enable all debug messages, and to 2 to disable info messages
 
 /* Puppy Pawz Pampers Variables */

--- a/menu.lsl
+++ b/menu.lsl
@@ -76,7 +76,7 @@ vector g_plasticPantsSize;
 string g_exitText = ""; //text entered here will be spoken to the owner when the diaper is removed.
 string g_diaperType = "Fluffems";
 string g_updateScript = "ME Wireless DrizzleScript Updater";
-integer isDebug = FALSE;
+integer isDebug = TRUE;
 //set isDebug to 1 (TRUE) to enable all debug messages, and to 2 to disable info messages
 
 /* Puppy Pawz Pampers Variables */
@@ -326,7 +326,6 @@ sendSettings() {
     (string) g_WetVolume + "," +
     (string) g_MessVolume + "," +
     (string) g_PlasticPants;
-    //For lite consider shifting to LINK_THIS
     llMessageLinked(LINK_ALL_OTHERS, 6, csv, NULL_KEY);
     llMessageLinked(LINK_THIS, -6, csv, NULL_KEY);
 }
@@ -341,7 +340,6 @@ integer generateChan(key id) {
 // @type = The form of diaper use to be attempted.
 // Case 1: Success, Held it, printout
 // Case 2: Failure, Had an Accident,  printout
-// Future Feature(in code now): Holding it will reduce chance to hold it in the future.
 integer findPercentage(string type) {
     // Add check for trainer mode.
     integer toCheck;
@@ -628,16 +626,6 @@ printDebugSettings() {
     llOwnerSay("Free Memory: " + (string) llGetFreeMemory());
 }
 
-/* Simple function that searches g_Carers for a given user name */
-integer isCarer(string name) {
-    if(~llListFindList(g_Carers, [name])) { // name found, they're a carer!
-        return TRUE;
-    }
-    else {
-        return FALSE;
-    }
-}
-
 /* Basic function for printing out the carer's list with a header */
 printCarers() {
     llOwnerSay("Carer List: " + llDumpList2String(g_Carers,", "));
@@ -699,7 +687,7 @@ integer getToucherRank(key id) {
     if(id == llGetOwner()) {
         return 0;
     }
-    else if(isCarer(llKey2Name(id))) { // Carer (This is safe because the Carer is guaranteed to be in the sim)
+    else if(~llListFindList(g_Carers, [llKey2Name(id)])) { // Carer (This is safe because the Carer is guaranteed to be in the sim)
         return 1;
     }
     else {


### PR DESCRIPTION
We need to address steak/heap collision issue #52 right away.  Depreciating isCarer reduces the memory load adding carers needs, while moving plastic pants handling to Preferences where the option is located anyway helps free up an awful lot of memory making it possible to run under more normal conditions.  Carer list adding is being worked on, and we're no longer depending on the carer list memory core being synchronized with the internal memory one- it's to be considered a backup of the current carer list.  It'll hold 10 avatars reliably, which is more than I imagined it should be able to hold.
